### PR TITLE
Revert usage of copilot cmp

### DIFF
--- a/.config/nvim/lua/plugins/autocomplete.lua
+++ b/.config/nvim/lua/plugins/autocomplete.lua
@@ -41,17 +41,6 @@ return { -- Autocompletion
     luasnip.config.setup {}
 
     cmp.setup {
-      formatting = {
-        fields = { 'abbr', 'kind', 'menu' },
-        expandable_indicator = true,
-        format = function(entry, item)
-          if entry.source.name == 'copilot' then
-            item.kind = ' Copilot'
-          end
-
-          return item
-        end,
-      },
       window = {
         completion = cmp.config.window.bordered(),
         documentation = cmp.config.window.bordered(),
@@ -122,7 +111,6 @@ return { -- Autocompletion
             return require('cmp.types').lsp.CompletionItemKind[entry:get_kind()] ~= 'Text'
           end,
         },
-        { name = 'copilot' },
         { name = 'luasnip', group_index },
         { name = 'path' },
       },

--- a/.config/nvim/lua/plugins/copilot-cmp.lua
+++ b/.config/nvim/lua/plugins/copilot-cmp.lua
@@ -1,6 +1,0 @@
-return {
-  'zbirenbaum/copilot-cmp',
-  config = function()
-    require('copilot_cmp').setup()
-  end,
-}

--- a/.config/nvim/lua/plugins/copilot.lua
+++ b/.config/nvim/lua/plugins/copilot.lua
@@ -1,14 +1,1 @@
-return {
-  'zbirenbaum/copilot.lua',
-  config = function()
-    require('copilot').setup {
-      panel = {
-        -- auto_refresh = true
-      },
-      suggestion = {
-        enabled = false,
-        auto_trigger = true,
-      },
-    }
-  end,
-}
+return { 'github/copilot.vim' }


### PR DESCRIPTION
Copilot cmp puts copilots suggetions in a cmp buffer.

I dislike this for a number of reasons: 
1. It makes it harder to see what copilot is suggesting particulary when using split windows. The cmp floating popup is not always visible.
2. Accidental selection of multiline input with enter is a pain.
3. Copilot only suggests when you prompt cmp or start typing.

Reverting at the moment but may merge again after figuring out a better integration.

- **Revert "use copilot icon in cmp"**
- **Revert "switch to copilot-cmp from github copilot"**
- **Revert "setup copilot-cmp"**
